### PR TITLE
migrate from butterknife to android data binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
+    dataBinding {
+        enabled = true
+    }
     defaultConfig {
         applicationId "com.robotsandpencils.androiddaggerpractice1"
         minSdkVersion 27
@@ -47,7 +50,7 @@ dependencies {
     // implementation "com.google.dagger:dagger-android:$project.daggerVersion
 
     // ButterKnife
-    compile "com.jakewharton:butterknife:$project.butterKnifeVersion"
-    annotationProcessor "com.jakewharton:butterknife-compiler:$project.butterKnifeVersion"
+//    compile "com.jakewharton:butterknife:$project.butterKnifeVersion"
+//    annotationProcessor "com.jakewharton:butterknife-compiler:$project.butterKnifeVersion"
 
 }

--- a/app/src/main/java/com/robotsandpencils/androiddaggerpractice1/lobby/LobbyActivity.java
+++ b/app/src/main/java/com/robotsandpencils/androiddaggerpractice1/lobby/LobbyActivity.java
@@ -1,23 +1,20 @@
 package com.robotsandpencils.androiddaggerpractice1.lobby;
 
 import android.app.Fragment;
-//import android.support.v4.app.Fragment;
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.widget.TextView;
 
 import com.robotsandpencils.androiddaggerpractice1.R;
 import com.robotsandpencils.androiddaggerpractice1.common.CommonHelloService;
+import com.robotsandpencils.androiddaggerpractice1.databinding.LobbyActivityBinding;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
 import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasFragmentInjector;
-import dagger.android.support.HasSupportFragmentInjector;
 
 /**
  * Created by pwray on 2017-10-30.
@@ -29,7 +26,6 @@ import dagger.android.support.HasSupportFragmentInjector;
  */
 
 public class LobbyActivity extends AppCompatActivity implements HasFragmentInjector {
-//public class LobbyActivity extends AppCompatActivity implements HasSupportFragmentInjector {
 
     @Inject
     DispatchingAndroidInjector<Fragment> fragmentDispatchingAndroidInjector;
@@ -40,18 +36,15 @@ public class LobbyActivity extends AppCompatActivity implements HasFragmentInjec
     @Inject
     LobbyHelloService lobbyHelloService;
 
-    @BindView(R.id.common_hello)
-    TextView commonHelloTextView;
-
-    @BindView(R.id.lobby_hello)
-    TextView lobbyHelloTextView;
+    private LobbyActivityBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         AndroidInjection.inject(this);
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.lobby_activity);
-        ButterKnife.bind(this);
+
+        // migrate to data binding
+        binding = DataBindingUtil.setContentView(this, R.layout.lobby_activity);
     }
 
     @Override
@@ -62,11 +55,11 @@ public class LobbyActivity extends AppCompatActivity implements HasFragmentInjec
     }
 
     private void sayCommonHello() {
-        commonHelloTextView.setText(commonHelloService.sayHello());
+        binding.commonHello.setText(commonHelloService.sayHello());
     }
 
     private void sayLobbyHello() {
-        lobbyHelloTextView.setText(lobbyHelloService.sayHello());
+        binding.lobbyHello.setText(lobbyHelloService.sayHello());
     }
 
     @Override
@@ -74,8 +67,4 @@ public class LobbyActivity extends AppCompatActivity implements HasFragmentInjec
         return fragmentDispatchingAndroidInjector;
     }
 
-//    @Override
-//    public AndroidInjector<Fragment> supportFragmentInjector() {
-//        return fragmentDispatchingAndroidInjector;
-//    }
 }

--- a/app/src/main/java/com/robotsandpencils/androiddaggerpractice1/lobby/LobbyFragment.java
+++ b/app/src/main/java/com/robotsandpencils/androiddaggerpractice1/lobby/LobbyFragment.java
@@ -1,24 +1,20 @@
 package com.robotsandpencils.androiddaggerpractice1.lobby;
 
 import android.app.Fragment;
-//import android.support.v4.app.Fragment;
 import android.content.Context;
+import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import com.robotsandpencils.androiddaggerpractice1.R;
+import com.robotsandpencils.androiddaggerpractice1.databinding.LobbyFragmentBinding;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import butterknife.Unbinder;
 import dagger.android.AndroidInjection;
-//import dagger.android.support.AndroidSupportInjection;
 
 /**
  * Created by pwray on 2017-10-30.
@@ -29,10 +25,7 @@ public class LobbyFragment extends Fragment {
     @Inject
     LobbyFragmentHelloService lobbyFragmentHelloService;
 
-    @BindView(R.id.lobby_fragment_hello)
-    TextView lobbyFragmentHelloTextView;
-
-    private Unbinder unbinder;
+    private LobbyFragmentBinding binding;
 
     @Override
     public void onAttach(Context context) {
@@ -46,8 +39,9 @@ public class LobbyFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.lobby_fragment, container, false);
-        unbinder = ButterKnife.bind(this, view);
+        binding = DataBindingUtil.inflate(inflater, R.layout.lobby_fragment, container, false);
+        View view = binding.getRoot();
+
         return view;
     }
 
@@ -60,10 +54,10 @@ public class LobbyFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
-        unbinder.unbind();
+        binding.unbind();
     }
 
     private void sayFragmentHello() {
-        lobbyFragmentHelloTextView.setText(lobbyFragmentHelloService.sayHello());
+        binding.lobbyFragmentHello.setText(lobbyFragmentHelloService.sayHello());
     }
 }

--- a/app/src/main/res/layout/lobby_activity.xml
+++ b/app/src/main/res/layout/lobby_activity.xml
@@ -1,31 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              tools:context="com.robotsandpencils.androiddaggerpractice1.lobby.LobbyActivity">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/common_hello"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="30dp" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context="com.robotsandpencils.androiddaggerpractice1.lobby.LobbyActivity">
 
-    <TextView
-        android:id="@+id/lobby_hello"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="30dp" />
+        <TextView
+            android:id="@+id/common_hello"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="30dp"/>
 
-    <fragment
-        android:id="@+id/lobby_fragment"
-        android:name="com.robotsandpencils.androiddaggerpractice1.lobby.LobbyFragment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="30dp" />
+        <TextView
+            android:id="@+id/lobby_hello"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="30dp"/>
 
-</LinearLayout>
+        <fragment
+            android:id="@+id/lobby_fragment"
+            android:name="com.robotsandpencils.androiddaggerpractice1.lobby.LobbyFragment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="30dp"/>
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/lobby_fragment.xml
+++ b/app/src/main/res/layout/lobby_fragment.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <TextView
-        android:id="@+id/lobby_fragment_hello"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-</FrameLayout>
+        <TextView
+            android:id="@+id/lobby_fragment_hello"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+    </FrameLayout>
+
+</layout>


### PR DESCRIPTION
Promotes the app from using butterknife to using android data binding.

## How to test
- run the app, expect the data binding to assist the setting of the text views.

## Changelog
- Lobby activity and fragment use data binding
- the app `build.grade` removes its butterknife dependency